### PR TITLE
feat: Add X (Twitter) sharing functionality and mobile optimization

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -128,6 +128,40 @@ html, body {
   transform: translateY(1px);
 }
 
+/* X投稿ボタンのスタイル */
+.twitter-button {
+  background: linear-gradient(135deg, #1da1f2, #0d8bd9) !important;
+  color: #ffffff !important;
+}
+
+.twitter-button:hover,
+.twitter-button:focus {
+  background: linear-gradient(135deg, #0d8bd9, #0a6bb3) !important;
+  box-shadow: 0 6px 16px rgba(29, 161, 242, 0.4) !important;
+}
+
+.twitter-button:active {
+  background: linear-gradient(135deg, #0a6bb3, #085a9c) !important;
+}
+
+.twitter-button.active {
+  background: linear-gradient(135deg, #0a6bb3, #085a9c) !important;
+}
+
+/* ボタングループのスタイル */
+.overlay-button-group {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.overlay-button-group .overlay-button {
+  flex: 1;
+  min-width: 140px;
+  max-width: 200px;
+}
+
 .hud-extra {
   position: absolute;
   left: 12px;

--- a/js/main.js
+++ b/js/main.js
@@ -67,6 +67,29 @@ overlay.addEventListener('pointerdown', (e) => {
   });
 });
 
+// X投稿機能
+function shareToTwitter() {
+  const distance = game.formattedCurrentDistance();
+  const stage = game.stageIndex + 1;
+  const isGameClear = game.state === 'gameclear';
+  
+  let text;
+  if (isGameClear) {
+    text = `🚀 Cave Escape 全ステージクリア！\nクリア距離: ${distance} km\n\n#CaveEscape #ゲーム`;
+  } else {
+    text = `🚀 Cave Escape で ${distance} km 到達！\nステージ ${stage} でゲームオーバー\n\n#CaveEscape #ゲーム`;
+  }
+  
+  const url = 'https://github.com/wikeda/Cave-Escape';
+  const hashtags = 'CaveEscape,ゲーム,アクションゲーム';
+  
+  // XのWeb Intent URLを作成
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${encodeURIComponent(hashtags)}`;
+  
+  // 新しいタブでX投稿画面を開く
+  window.open(twitterUrl, '_blank', 'width=600,height=400');
+}
+
 function handleAction(action) {
   switch (action) {
     case 'start':
@@ -80,6 +103,9 @@ function handleAction(action) {
       break;
     case 'continue':
       game.nextStageOrClear();
+      break;
+    case 'tweet':
+      shareToTwitter();
       break;
     default:
       break;
@@ -175,11 +201,16 @@ function frame(now) {
   } else if (game.state === 'gameover') {
     game.draw();
     const distance = game.formattedCurrentDistance();
+    const stage = game.stageIndex + 1;
     setOverlay([
       `<div class="overlay-panel">
         <h1>ゲームオーバー</h1>
         <p>到達距離: ${distance} km</p>
-        <button class="overlay-button" data-action="restart">タイトルへ戻る</button>
+        <p>ステージ: ${stage}</p>
+        <div class="overlay-button-group">
+          <button class="overlay-button" data-action="restart">タイトルへ戻る</button>
+          <button class="overlay-button twitter-button" data-action="tweet">Xに投稿</button>
+        </div>
       </div>`
     ], { interactive: true });
     setHudExtra([
@@ -189,12 +220,16 @@ function frame(now) {
     pauseBtn?.classList.add('hidden');
   } else if (game.state === 'gameclear') {
     game.draw();
+    const distance = game.formattedCurrentDistance();
     setOverlay([
       `<div class="overlay-panel">
         <h1>全ステージクリア！</h1>
         <p>おめでとうございます！</p>
-        <p>クリア距離: ${game.formattedCurrentDistance()} km</p>
-        <button class="overlay-button" data-action="restart">タイトルへ戻る</button>
+        <p>クリア距離: ${distance} km</p>
+        <div class="overlay-button-group">
+          <button class="overlay-button" data-action="restart">タイトルへ戻る</button>
+          <button class="overlay-button twitter-button" data-action="tweet">Xに投稿</button>
+        </div>
       </div>`
     ], { interactive: true });
     setHudExtra([


### PR DESCRIPTION
## 概要
ゲームオーバー・クリア画面にX（Twitter）投稿機能を追加し、モバイル最適化を実装しました。

## 追加機能
- **X投稿機能**
  - ゲームオーバー画面でスコアとステージをXに投稿可能
  - ゲームクリア画面でクリア距離をXに投稿可能
  - XのWeb Intent APIを使用して新しいタブで投稿画面を開く
  - 自動的にハッシュタグ（#CaveEscape #ゲーム）とURLを含める

- **UI/UX改善**
  - ボタングループでレイアウトを整理
  - X投稿ボタンにXブランドカラーのスタイリングを適用
  - レスポンシブデザイン対応

## 技術的詳細
- `shareToTwitter()` 関数でX投稿機能を実装
- ゲーム状態に応じて異なるメッセージを自動生成
- `handleAction()` に `tweet` アクションを追加
- CSSでX投稿ボタンの専用スタイルを定義

## テスト
- [x] ゲームオーバー画面でのX投稿機能
- [x] ゲームクリア画面でのX投稿機能
- [x] モバイルデバイスでの表示確認
- [x] ボタンのレスポンシブレイアウト

## スクリーンショット
ゲームオーバー画面に「Xに投稿」ボタンが追加され、クリックするとXの投稿画面が新しいタブで開きます。